### PR TITLE
Fix #17: Refined parser link detection regex

### DIFF
--- a/ejira-parser.el
+++ b/ejira-parser.el
@@ -98,7 +98,7 @@
                        jiralib2-url username name))))
 
         ;; Link
-        ("\\[\\(?:\\(.*\\)|\\)?\\([^\\]*\\)\\]"
+        ("\\[\\(?:\\(.*?\\)\\)?|\\([^\\]*?\\)\\]"
          . (lambda ()
              (let ((url (format "[%s]" (match-string 2)))
                    (placeholder (if (match-string 1)


### PR DESCRIPTION
The parser link regex now requires the '|' separator, it no longer mistakes bracketed comments for links as a result.

* quantifiers for links were also adjusted to be lazy, which should eliminate some of the weirder link processing edge cases.